### PR TITLE
feat(equipe organizadora): link nas rotas e nomes da equipe

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,6 @@ app.get('/simposio/2026/educomp', educomp_2026_home.home)
 app.get('/simposio/2026/educomp/chamadas/topicos-de-interesse', educomp_2026_chamadas.topicos_interesse)
 app.get('/simposio/2026/educomp/chamadas/artigos-completos', educomp_2026_chamadas.artigos_completos)
 app.get('/simposio/2026/educomp/equipes/comissao-organizadora', educomp_2026_equipes.comissao_organizadora)
-app.get('/simposio/2026/educomp/equipes/comite-programa', educomp_2026_equipes.comite_programa)
-app.get('/simposio/2026/educomp/equipes/comite-diretivo', educomp_2026_equipes.comite_diretivo)
-app.get('/simposio/2026/educomp/equipes/comissao-especial', educomp_2026_equipes.comissao_especial)
 app.get(new RegExp('/simposio/2026/educomp/(.*)', 'i'), educomp_2026_comming.comming)
 
 

--- a/index.js
+++ b/index.js
@@ -27,12 +27,18 @@ app.get('/documentos/modelos/proposta-sede-educomp', giec_main.documentos_modelo
 var educomp_2026_home = require('./routes/simposio/2026/educomp/pt-BR/home')
 var educomp_2026_comming = require('./routes/simposio/2026/educomp/pt-BR/comming')
 var educomp_2026_chamadas = require('./routes/simposio/2026/educomp/pt-BR/chamadas')
+var educomp_2026_equipes = require('./routes/simposio/2026/educomp/pt-BR/equipes')
 
 app.get('/simposio/2026', educomp_2026_home.home)
 app.get('/simposio/2026/educomp', educomp_2026_home.home)
 app.get('/simposio/2026/educomp/chamadas/topicos-de-interesse', educomp_2026_chamadas.topicos_interesse)
 app.get('/simposio/2026/educomp/chamadas/artigos-completos', educomp_2026_chamadas.artigos_completos)
+app.get('/simposio/2026/educomp/equipes/comissao-organizadora', educomp_2026_equipes.comissao_organizadora)
+app.get('/simposio/2026/educomp/equipes/comite-programa', educomp_2026_equipes.comite_programa)
+app.get('/simposio/2026/educomp/equipes/comite-diretivo', educomp_2026_equipes.comite_diretivo)
+app.get('/simposio/2026/educomp/equipes/comissao-especial', educomp_2026_equipes.comissao_especial)
 app.get(new RegExp('/simposio/2026/educomp/(.*)', 'i'), educomp_2026_comming.comming)
+
 
 // Educomp 2025
 var educomp_2025_home = require('./routes/simposio/2025/educomp/pt-BR/home')

--- a/routes/simposio/2026/educomp/pt-BR/equipes.js
+++ b/routes/simposio/2026/educomp/pt-BR/equipes.js
@@ -1,0 +1,35 @@
+exports.comissao_organizadora = function (req, res) {
+  res.render('simposio/2026/educomp/pt-BR/equipes/comissao-organizadora', {
+    layout: 'simposio/2026/pt-BR/layout',
+    equipes: true,
+    isEducomp: true,
+    titulo: 'Comissão organizadora',
+  })
+}
+
+exports.comite_programa = function (req, res) {
+  res.render('simposio/2026/educomp/pt-BR/equipes/comite-programa', {
+    layout: 'simposio/2026/pt-BR/layout',
+    equipes: true,
+    isEducomp: true,
+    titulo: 'Comitê de programa',
+  })
+}
+
+exports.comite_diretivo = function (req, res) {
+  res.render('simposio/2026/educomp/pt-BR/equipes/comite-diretivo', {
+    layout: 'simposio/2026/pt-BR/layout',
+    equipes: true,
+    isEducomp: true,
+    titulo: 'Comitê diretivo',
+  })
+}
+
+exports.comissao_especial = function (req, res) {
+  res.render('simposio/2026/educomp/pt-BR/equipes/comissao-especial', {
+    layout: 'simposio/2026/pt-BR/layout',
+    equipes: true,
+    isEducomp: true,
+    titulo: 'Comissão especial',
+  })
+}

--- a/views/simposio/2026/educomp/pt-BR/equipes/comissao-organizadora.handlebars
+++ b/views/simposio/2026/educomp/pt-BR/equipes/comissao-organizadora.handlebars
@@ -13,24 +13,12 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Alessandreia Marta de Oliveira</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Amaury Antônio de Castro Junior</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Edmar Welington Oliveira</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Jairo Francisco de Souza</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Luciano Jerez Chaves</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Pedro Henrique Dias Valle</td>
-                <td data-label="Instituição">USP</td>
+                <td data-label="Nome">Anderson Corrêa de Lima</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
             </tbody>
           </table>
@@ -45,20 +33,12 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Ivanilse Calderon</td>
-                <td data-label="Instituição">IFRO</td>
+                <td data-label="Nome">Said Sadique Aidi</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Renato de Souza Garcia</td>
-                <td data-label="Instituição">IFMS</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Ricardo Ferreira Vilela</td>
-                <td data-label="Instituição">UFCA</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Williamson Silva</td>
-                <td data-label="Instituição">UNIPAMPA</td>
+                <td data-label="Nome">Valéria Quadros dos Reis</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
             </tbody>
           </table>
@@ -73,12 +53,12 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Alessandreia Marta de Oliveira</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Luciano Gonda</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Jairo Francisco de Souza</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Said Sadique Aidi</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
             </tbody>
           </table>
@@ -93,16 +73,16 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Cleon Xavier Pereira Júnior</td>
-                <td data-label="Instituição">IF-Goiano</td>
+                <td data-label="Nome">Nahri Balesdent Moreano</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Esdras Bispo Jr.</td>
-                <td data-label="Instituição">UFJ</td>
+                <td data-label="Nome">Said Sadique Aidi</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Pedro Henrique Dias Valle</td>
-                <td data-label="Instituição">USP</td>
+                <td data-label="Nome">Valéria Quadros dos Reis</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
                 <td data-label="Nome">Yorah Bosse</td>
@@ -121,40 +101,8 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Alessandreia Marta de Oliveira</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Ana Luiza Mello</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Ana Luiza Miscoli</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Edmar Welington Oliveira</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Felipe Vasconcellos Strehle</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Isabela Freesz Vellasco</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">João Ricardo Bernardo</td>
-                <td data-label="Instituição">UFAM</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Julia Borges Beccari</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Pedro Henrique Dias Valle</td>
-                <td data-label="Instituição">USP</td>
+                <td data-label="Nome">Ana Karina Dourado Salina de Oliveira</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
             </tbody>
           </table>
@@ -169,40 +117,20 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Caio Nascimento Reis da Silva</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Amanda Caroline de Gois Balcaçar</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Estêvão Barbosa Fiorilo Rocha</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Ana Karina Dourado Salina de Oliveira</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Helena Lannes</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Awdren de Lima Fontão</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Jairo Francisco de Souza</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Leandro Carlos de Melo Filho</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Leonardo Prata</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Luciano Jerez Chaves</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Miguel Dias de Abreu</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Thiago José Lopes</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Hudson Silva Borges</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
             </tbody>
           </table>
@@ -217,112 +145,32 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Alessandreia Marta de Oliveira</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Anderson Viçoso de Araújo</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Alexya Vitoria de Jesus Silva</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Edson Norberto Cáceres</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Ana Clara Laredo Miranda</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Glauder Guimarães Ghinozzi</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Ana Luiza Almeida Míscoli</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Luciano Gonda</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Caio Nascimento Reis da Silva</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Mariana Caravanti de Souza</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Cauã Moreno Lopes Castro</td>
-                <td data-label="Instituição">UFJF</td>
+                <td data-label="Nome">Said Sadique Aidi</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
-                <td data-label="Nome">Carlos Alexandre de Almeida Pires </td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Celso Gabriel Dutra Almeida Malosto</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Edmar Welington Oliveira</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Estêvão Barbosa Fiorilo da Rocha</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Felipe Vasconcellos Strehle</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Fernanda dos Santos Coutinho </td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Frederico Dôndici Gama Vieira</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Jairo Francisco de Souza</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">João Ricardo Serique Bernardo</td>
-                <td data-label="Instituição">UFAM</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Joel Henrique Nunes de Oliveira Silva</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Julia Borges Beccari</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Leandro Carlos de Melo Filho</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Luciano Jerez Chaves</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Marcelo Caniato Renhe</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Maria Clara Ribeiro de Menezes</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Miguel Dias de Abreu</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Nina Aguiar Ferreira</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Pedro Henrique Dias Valle </td>
-                <td data-label="Instituição">USP</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Rômulo Chrispim de Mello</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Samuel Nascimento Barbosa</td>
-                <td data-label="Instituição">UFJF</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Williamson Alison Freitas Silva</td>
-                <td data-label="Instituição">UNIPAMPA</td>
+                <td data-label="Nome">Valéria Quadros dos Reis</td>
+                <td data-label="Instituição">UFMS</td>
               </tr>
             </tbody>
           </table>

--- a/views/simposio/2026/educomp/pt-BR/equipes/comissao-organizadora.handlebars
+++ b/views/simposio/2026/educomp/pt-BR/equipes/comissao-organizadora.handlebars
@@ -84,10 +84,6 @@
                 <td data-label="Nome">Valéria Quadros dos Reis</td>
                 <td data-label="Instituição">UFMS</td>
               </tr>
-              <tr>
-                <td data-label="Nome">Yorah Bosse</td>
-                <td data-label="Instituição">University at Buffalo</td>
-              </tr>
             </tbody>
           </table>
 
@@ -149,11 +145,27 @@
                 <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
+                <td data-label="Nome">Bianca de Almeida Dantas</td>
+                <td data-label="Instituição">UFMS</td>
+              </tr>
+              <tr>
                 <td data-label="Nome">Edson Norberto Cáceres</td>
                 <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>
                 <td data-label="Nome">Glauder Guimarães Ghinozzi</td>
+                <td data-label="Instituição">UFMS</td>
+              </tr>
+              <tr>
+                <td data-label="Nome">Hana Karina Salles Rubinsztejn</td>
+                <td data-label="Instituição">UFMS</td>
+              </tr>
+              <tr>
+                <td data-label="Nome">Jonathan de Andrade Silva</td>
+                <td data-label="Instituição">UFMS</td>
+              </tr>
+              <tr>
+                <td data-label="Nome">Liana Dessandre Duenha</td>
                 <td data-label="Instituição">UFMS</td>
               </tr>
               <tr>


### PR DESCRIPTION
## O que este PR está fazendo?

Este pull request adiciona a rota de Equipe Organizadora e faz as edições dos nomes de equipe organizadora de acordo com a planilha 

## Como testar ?
1. Acessar /simposio/2026/educomp/equipes/comissao-organizadora