### PR TITLE
feat(equipes): link nas rotas e nomes da equipe

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ app.get('/simposio/2026/educomp/chamadas/artigos-completos', educomp_2026_chamad
 app.get('/simposio/2026/educomp/equipes/comissao-organizadora', educomp_2026_equipes.comissao_organizadora)
 app.get('/simposio/2026/educomp/equipes/comite-programa', educomp_2026_equipes.comite_programa)
 app.get('/simposio/2026/educomp/equipes/comissao-especial', educomp_2026_equipes.comissao_especial)
+app.get('/simposio/2026/educomp/equipes/comite-diretivo', educomp_2026_equipes.comite_diretivo)
 app.get(new RegExp('/simposio/2026/educomp/(.*)', 'i'), educomp_2026_comming.comming)
 
 

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ app.get('/simposio/2026/educomp', educomp_2026_home.home)
 app.get('/simposio/2026/educomp/chamadas/topicos-de-interesse', educomp_2026_chamadas.topicos_interesse)
 app.get('/simposio/2026/educomp/chamadas/artigos-completos', educomp_2026_chamadas.artigos_completos)
 app.get('/simposio/2026/educomp/equipes/comissao-organizadora', educomp_2026_equipes.comissao_organizadora)
+app.get('/simposio/2026/educomp/equipes/comite-programa', educomp_2026_equipes.comite_programa)
 app.get(new RegExp('/simposio/2026/educomp/(.*)', 'i'), educomp_2026_comming.comming)
 
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ app.get('/simposio/2026/educomp/chamadas/topicos-de-interesse', educomp_2026_cha
 app.get('/simposio/2026/educomp/chamadas/artigos-completos', educomp_2026_chamadas.artigos_completos)
 app.get('/simposio/2026/educomp/equipes/comissao-organizadora', educomp_2026_equipes.comissao_organizadora)
 app.get('/simposio/2026/educomp/equipes/comite-programa', educomp_2026_equipes.comite_programa)
+app.get('/simposio/2026/educomp/equipes/comissao-especial', educomp_2026_equipes.comissao_especial)
 app.get(new RegExp('/simposio/2026/educomp/(.*)', 'i'), educomp_2026_comming.comming)
 
 

--- a/views/simposio/2026/educomp/pt-BR/equipes/comissao-especial.handlebars
+++ b/views/simposio/2026/educomp/pt-BR/equipes/comissao-especial.handlebars
@@ -13,12 +13,12 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Rodrigo Duran</td>
-                <td data-label="Instituição">IFB</td>        
+                <td data-label="Nome">Alessandreia Marta de Oliveira</td>
+                <td data-label="Instituição">UFJF</td>
               </tr>
               <tr>
-                <td data-label="Nome">Rozelma Soares de França</td>
-                <td data-label="Instituição">UFRPE</td>
+                <td data-label="Nome">Graziela Guarda</td>
+                <td data-label="Instituição">UFF</td>        
               </tr>
             </tbody>
           </table>
@@ -33,20 +33,24 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Graziela Guarda</td>
-                <td data-label="Instituição">UFF</td>
+                <td data-label="Nome">Amaury Antonio de Castro Junior</td>
+                <td data-label="Instituição">UFMS</td>
+              </tr>
+              <tr>
+                <td data-label="Nome">Diego Berti Bagestan</td>
+                <td data-label="Instituição">SMEd Teutônia/RS</td>
               </tr>
               <tr>
                 <td data-label="Nome">Gustavo de Oliveira Andrade</td>
                 <td data-label="Instituição">IFRJ</td>
               </tr>
               <tr>
-                <td data-label="Nome">Rodrigo Duran</td>
-                <td data-label="Instituição">IFB</td>
+                <td data-label="Nome">Marcela Savia Picanco Pessoa</td>
+                <td data-label="Instituição">UEA</td>
               </tr>
               <tr>
-                <td data-label="Nome">Rozelma Soares de França</td>
-                <td data-label="Instituição">UFRPE</td>
+                <td data-label="Nome">Rodrigo Duran</td>
+                <td data-label="Instituição">IFB</td>
               </tr>
               <tr>
                 <td data-label="Nome">Sheila Reinehr</td>

--- a/views/simposio/2026/educomp/pt-BR/equipes/comite-diretivo.handlebars
+++ b/views/simposio/2026/educomp/pt-BR/equipes/comite-diretivo.handlebars
@@ -9,49 +9,28 @@
               <tr class="text-uppercase font-weight-bold text-center">
                 <td class="col-nome">Nome</td>
                 <td class="col-inst">Instituição</td>
-                <!--<td class="col-mail">E-mail</td> -->
               </tr>
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Alessandreia Marta de Oliveira</td>
-                <td data-label="Instituição">UFJF</td>
-                <!--<td data-label="E-mail">alessandreia.oliveira@ufjf.br</td> -->
-              </tr>
-              <tr>
                 <td data-label="Nome">Graziela Guarda</td>
                 <td data-label="Instituição">UFF</td>
-                <!--<td data-label="E-mail">grazielaguarda@id.uff.br</td> -->
               </tr>
               <tr>
-                <td data-label="Nome">Leandro Galvão</td>
+                <td data-label="Nome">Leandro Silva Galvão de Carvalho</td>
                 <td data-label="Instituição">UFAM</td>
-                <!--<td data-label="E-mail">galvao@icomp.ufam.edu.br</td> -->
-              </tr>
-              <tr>
-                <td data-label="Nome">Leila Ribeiro</td>
-                <td data-label="Instituição">UFRGS</td>
-                <!--<td data-label="E-mail">leila@inf.ufrgs.br</td>-->
               </tr>
               <tr>
                 <td data-label="Nome">Marco Aurélio Graciotto Silva</td>
                 <td data-label="Instituição">UTFPR</td>
-                <!--<td data-label="E-mail">magsilva@utfpr.edu.br</td>-->
               </tr>
               <tr>
-                <td data-label="Nome">Nathalia Cruz Alves</td>
-                <td data-label="Instituição">UFSC</td>
-                <!--<td data-label="E-mail">nathalia.alves@posgrad.ufsc.br</td>-->
+                <td data-label="Nome">Ricardo Edgard Caceffo</td>
+                <td data-label="Instituição">UNIVESP</td>
               </tr>
               <tr>
-                <td data-label="Nome">Rodrigo Duran</td>
-                <td data-label="Instituição">IFB</td>
-                <!--<td data-label="E-mail">rodrigo.duran@ifms.edu.br</td>-->
-              </tr>
-              <tr>
-                <td data-label="Nome">Silvia Amélia Bim</td>
-                <td data-label="Instituição">UTFPR</td>
-                <!--<td data-label="E-mail">sabim@utfpr.edu.br</td>-->
+                <td data-label="Nome">Williamson Silva</td>
+                <td data-label="Instituição">UFCA</td>
               </tr>
             </tbody>
           </table>

--- a/views/simposio/2026/educomp/pt-BR/equipes/comite-programa.handlebars
+++ b/views/simposio/2026/educomp/pt-BR/equipes/comite-programa.handlebars
@@ -89,12 +89,12 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Taciana Pontual</td>
-                <td data-label="Instituição">UFRPE</td>
-              </tr>
-              <tr>
                 <td data-label="Nome">Alessandreia Marta de Oliveira</td>
                 <td data-label="Instituição">UFJF</td>
+              </tr>
+              <tr>
+                <td data-label="Nome">Taciana Pontual</td>
+                <td data-label="Instituição">UFRPE</td>
               </tr>
             </tbody>
           </table>

--- a/views/simposio/2026/educomp/pt-BR/equipes/comite-programa.handlebars
+++ b/views/simposio/2026/educomp/pt-BR/equipes/comite-programa.handlebars
@@ -16,6 +16,10 @@
                 <td data-label="Nome">Leandro Silva Galvão de Carvalho</td>
                 <td data-label="Instituição">UFAM</td>
               </tr>
+              <tr>
+                <td data-label="Nome">Ricardo Caceffo</td>
+                <td data-label="Instituição">Univesp</td>
+              </tr>
             </tbody>
           </table>
 
@@ -29,8 +33,8 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Nathalia da Cruz Alves</td>
-                <td data-label="Instituição">Georgetown University</td>
+                <td data-label="Nome">Williamson Silva</td>
+                <td data-label="Instituição">UFCA</td>
               </tr>
             </tbody>
           </table>
@@ -45,12 +49,12 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Jean Carlo Rossa Hauck</td>
-                <td data-label="Instituição">UFSC</td>
+                <td data-label="Nome">Eryck Silva</td>
+                <td data-label="Instituição">Unicamp</td>
               </tr>
               <tr>
-                <td data-label="Nome">Ricardo Edgard Caceffo</td>
-                <td data-label="Instituição">Univesp</td>
+                <td data-label="Nome">Yorah Bosse</td>
+                <td data-label="Instituição">University of Buffalo</td>
               </tr>
             </tbody>
           </table>
@@ -65,12 +69,12 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Kiev Santos da Gama</td>
-                <td data-label="Instituição">UFPE</td>
+                <td data-label="Nome">Fernanda Pires</td>
+                <td data-label="Instituição">UEA</td>
               </tr>
               <tr>
-                <td data-label="Nome">Luciana Foss</td>
-                <td data-label="Instituição">UFPel</td>
+                <td data-label="Nome">Luciano Ferreira</td>
+                <td data-label="Instituição">UFRR</td>
               </tr>
             </tbody>
           </table>
@@ -85,12 +89,12 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Ana Paula Lüdtke Ferreira</td>
-                <td data-label="Instituição">UNIPAMPA</td>
+                <td data-label="Nome">Taciana Pontual</td>
+                <td data-label="Instituição">UFRPE</td>
               </tr>
               <tr>
-                <td data-label="Nome">Ana Liz Souto Oliveira</td>
-                <td data-label="Instituição">UFPB</td>
+                <td data-label="Nome">Alessandreia Marta de Oliveira</td>
+                <td data-label="Instituição">UFJF</td>
               </tr>
             </tbody>
           </table>
@@ -105,12 +109,12 @@
             </thead>
             <tbody class="text-center">
               <tr>
-                <td data-label="Nome">Rafaela Vilela da Rocha</td>
-                <td data-label="Instituição">UFABC</td>
-              </tr>
-              <tr>
                 <td data-label="Nome">Eduardo Figueiredo</td>
                 <td data-label="Instituição">UFMG</td>
+              </tr>
+              <tr>
+                <td data-label="Nome">Ronney Castro</td>
+                <td data-label="Instituição">UFJF</td>
               </tr>
             </tbody>
           </table>
@@ -131,94 +135,6 @@
               <tr>
                 <td data-label="Nome">João Paulo Alres</td>
                 <td data-label="Instituição">UTFPR</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <table class="table table-striped">
-            <h2>Laboratório de ideias</h2>
-            <thead>
-              <tr class="text-uppercase font-weight-bold text-center">
-                <td class="col-nome">Nome</td>
-                <td class="col-inst">Instituição</td>
-              </tr>
-            </thead>
-            <tbody class="text-center">
-              <tr>
-                <td data-label="Nome">Esdras Bispo Jr.</td>
-                <td data-label="Instituição">UFJ</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <table class="table table-striped">
-            <h2>WTD - Workshop de teses e dissertações</h2>
-            <thead>
-              <tr class="text-uppercase font-weight-bold text-center">
-                <td class="col-nome">Nome</td>
-                <td class="col-inst">Instituição</td>
-              </tr>
-            </thead>
-            <tbody class="text-center">
-              <tr>
-                <td data-label="Nome">Milene Selbach Silveira</td>
-                <td data-label="Instituição">PUCRS</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Taciana Pontual Falção</td>
-                <td data-label="Instituição">UFRPE</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <table class="table table-striped">
-            <h2>CTD - Concurso de teses e dissertações</h2>
-            <thead>
-              <tr class="text-uppercase font-weight-bold text-center">
-                <td class="col-nome">Nome</td>
-                <td class="col-inst">Instituição</td>
-              </tr>
-            </thead>
-            <tbody class="text-center">
-              <tr>
-                <td data-label="Nome">Heitor Augustus Xavier Costa</td>
-                <td data-label="Instituição">UFLA</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <table class="table table-striped">
-            <h2>Coordenação de minicursos</h2>
-            <thead>
-              <tr class="text-uppercase font-weight-bold text-center">
-                <td class="col-nome">Nome</td>
-                <td class="col-inst">Instituição</td>
-              </tr>
-            </thead>
-            <tbody class="text-center">
-              <tr>
-                <td data-label="Nome">Amaury Antonio de Castro Junior</td>
-                <td data-label="Instituição">UFMS</td>
-              </tr>
-              <tr>
-                <td data-label="Nome">Anderson Correa de Lima</td>
-                <td data-label="Instituição">UFMS</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <table class="table table-striped">
-            <h2>Coordenação de mesas temáticas</h2>
-            <thead>
-              <tr class="text-uppercase font-weight-bold text-center">
-                <td class="col-nome">Nome</td>
-                <td class="col-inst">Instituição</td>
-              </tr>
-            </thead>
-            <tbody class="text-center">
-              <tr>
-                <td data-label="Nome">Ecivaldo de Souza Matos</td>
-                <td data-label="Instituição">USP</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
## O que este PR está fazendo?

Este pull request adiciona a rota de Equipe Organizadora, Diretiva e Especial.
Também faz as edições dos nomes de equipe de acordo com a planilha 

## Como testar ?
1. Acessar /simposio/2026/educomp/equipes/comite-programa
2. Acessar /simposio/2026/educomp/equipes/comissao-especial
3. Acessar /simposio/2026/educomp/equipes/comite-diretivo